### PR TITLE
Task/create common block buffer to logging thread

### DIFF
--- a/main.c
+++ b/main.c
@@ -42,6 +42,7 @@ int main(void) {
 
     while (true) {
         /* Currently the main thread doesn't executes tasks */
+        chprintf((BaseSequentialStream *)&SD1, "Block buffer occupancy: %d\r\n", buffer_occupancy(block_buffer));
         chThdSleepMilliseconds(500);
     }
 }

--- a/usr/inc/buffer.h
+++ b/usr/inc/buffer.h
@@ -1,0 +1,103 @@
+#ifndef BUFFER_H
+#define BUFFER_H
+
+#include <stdint.h>
+
+/*
+ * Constant variables and functions definitions
+ */
+
+/* Default action for when poping an element with the buffer empty. */
+#ifndef BUFFER_POP_EMPTY_ACTION
+#define BUFFER_POP_EMPTY_ACTION(buf, c) (c) = -1
+#endif /* BUFFER_POP_EMPTY_ACTION */
+
+/* Default action for when pushing an element with the buffer full.
+   For the case where we write over the oldest entry, note that there
+   is no protection against a concurrent pop call */
+#ifndef BUFFER_PUSH_FULL_ACTION
+#ifdef BUFFER_OVERWRITE_OLDEST_WHEN_FULL
+#define BUFFER_PUSH_FULL_ACTION(buf, c, ret_val) do {			\
+	(ret_val) = 0;							\
+	(buf).data[(buf).head] = (c);					\
+	(buf).head = (buf).new_head;					\
+	(buf).tail++;							\
+	if ((buf).tail >= buffer_size(buf))				\
+	    (buf).tail = 0;						\
+    } while (0)
+#else /* BUFFER_OVERWRITE_WHEN_FULL */
+#define BUFFER_PUSH_FULL_ACTION(buf, c, ret_val) do {	\
+    } while (0)
+#endif /* BUFFER_OVERWRITE_WHEN_FULL */
+#endif /*  BUFFER_PUSH_FULL_ACTION */
+
+
+/*
+ * Structs and types definitions
+ */
+
+#define BUFFER_STRUCT_DEF(ELEM_TYPE, IDX_TYPE, SIZE) struct {	\
+	ELEM_TYPE data[SIZE];					\
+	IDX_TYPE head;						\
+	IDX_TYPE tail;						\
+	IDX_TYPE new_head;					\
+	IDX_TYPE size;						\
+}
+
+#define BYTE_BUFFER_DEF(SIZE) BUFFER_STRUCT_DEF(uint8_t, uint8_t, SIZE)
+#define BYTE_LARGE_BUFFER_DEF(SIZE) BUFFER_STRUCT_DEF(uint8_t, uint16_t, SIZE)
+
+/*
+ * Macros to access the buffer
+ */
+
+#define buffer_reset(buf) do {						\
+	(buf).head = (buf).tail = 0;					\
+	(buf).size = sizeof((buf).data)/sizeof((buf).data[0]);		\
+    } while (0)
+
+#define buffer_size(buf) ((buf).size)
+
+#define buffer_occupancy(buf) (((buf).head >= (buf).tail ? 0 : buffer_size(buf)) \
+			      + (buf).head - (buf).tail)
+
+#define buffer_free_space(buf) buffer_size(buf) - 1 - buffer_occupancy(buf)
+
+#define is_buffer_empty(buf) ((buf).head == (buf).tail)
+
+#define is_buffer_full(buf) ((buf).head + 1 >= buffer_size(buf) ?	\
+			     (buf).tail == 0 : (buf).head + 1 == (buf).tail)
+
+#define buffer_generic_push(buf, c, ret_val, full_action, pos_push_action) do { \
+	(buf).new_head = (buf).head + 1;				\
+	if ((buf).new_head >= buffer_size(buf))				\
+	    (buf).new_head = 0;						\
+	if ((buf).new_head != (buf).tail) {				\
+	    (buf).data[(buf).head] = (c);				\
+	    (buf).head = (buf).new_head;				\
+	    (ret_val) = 0;						\
+	    pos_push_action(buf, c, ret_val);				\
+	} else {							\
+	    (ret_val) = -1;						\
+	    full_action(buf, c, ret_val);				\
+	}								\
+    } while (0)
+
+#define buffer_push(buf, c, ret_val) \
+    buffer_generic_push(buf, c, ret_val, BUFFER_PUSH_FULL_ACTION, {})
+
+#define buffer_generic_pop(buf, c, empty_action, pos_pop_action) do {	\
+	if ((buf).head == (buf).tail) {					\
+	    empty_action(buf, c);					\
+	}								\
+	else {								\
+	    (c) = (buf).data[(buf).tail];				\
+	    if (++((buf).tail) >= buffer_size(buf))			\
+		(buf).tail = 0;						\
+	    pos_pop_action(buf, c);					\
+	}								\
+    } while (0)
+
+#define buffer_pop(buf, c) buffer_generic_pop(buf, c, BUFFER_POP_EMPTY_ACTION, {})
+
+#endif /* BUFFER_H */

--- a/usr/inc/logger.h
+++ b/usr/inc/logger.h
@@ -6,14 +6,11 @@
 #include "chprintf.h"
 #include "usrconf.h"
 #include "ff.h"
-
-/* Include buffer library and set buffer to circular mode. */
-#define BUFFER_OVERWRITE_OLDEST_WHEN_FULL
-#include "buffer.h"
 /* Include data logger channels */
 #include "loggerconf.h"
 #include "logger_timing.h"
 #include "logger_analog_ch.h"
+#include "buffer.h"
 
 /*===========================================================================*/
 /* SD related settings.                                                              */
@@ -74,15 +71,6 @@ extern THD_WORKING_AREA(waLogThread, 2048);
 extern THD_FUNCTION(LogThread, arg);
 void logger_start(void);
 
-
-#define NUM_OF_FILES    5
-
-#define FIL_ANALOG      0
-#define FIL_DIGITAL     1
-#define FIL_IMU         2
-#define FIL_GPS         3
-#define FIL_CAN         4
-
 static const char filenames[5][12] = {
     "analog.dat",
     "digital.dat",
@@ -95,8 +83,5 @@ static const char filenames[5][12] = {
 #define FULLPATH_LEN    30      // Max. mumber of characters for full path
 
 static char filepaths[NUM_OF_FILES][FULLPATH_LEN];
-
-extern adcsample_t io_analog_buffer[IO_ANALOG_BUFFER_DEPTH * IO_ANALOG_NUM_CHANNELS];
-
 
 #endif

--- a/usr/inc/logger.h
+++ b/usr/inc/logger.h
@@ -6,33 +6,14 @@
 #include "chprintf.h"
 #include "usrconf.h"
 #include "ff.h"
-#include "logger_timing.h"
-#include "logger_analog_ch.h"
 
+/* Include buffer library and set buffer to circular mode. */
 #define BUFFER_OVERWRITE_OLDEST_WHEN_FULL
 #include "buffer.h"
-
-/*
- * Events to wake logger thread when a block is ready to be saved.
- */
-#define EVT_ADC_HALF_BUFFER EVENT_MASK(0)   // ADC Half Buffer complete event
-#define EVT_ADC_FULL_BUFFER EVENT_MASK(1)   // ADC Full Buffer complete event
-
-/*===========================================================================*/
-/* Analog I/O                                                                */
-/*===========================================================================*/
-
-#define IO_ANALOG_NUM_CHANNELS      8
-#define IO_DIGITAL_NUM_CHANNELS     8
-#define IO_ANALOG_BUFFER_DEPTH      60      // 60, 32 samples = 512 by. This gives us a half-buffer of 30 samples, leaving 4 bytes for timestamp (SD block has 512 bytes)
-
-#define LOGGER_FREQUENCY    200
-#define LOGGER_TIMER_PRE    TIMER_FREQUENCY/LOGGER_FREQUENCY
-
-/*
- * ADC buffer
- */
-extern adcsample_t io_analog_buffer[IO_ANALOG_BUFFER_DEPTH * IO_ANALOG_NUM_CHANNELS];
+/* Include data logger channels */
+#include "loggerconf.h"
+#include "logger_timing.h"
+#include "logger_analog_ch.h"
 
 /*===========================================================================*/
 /* SD related settings.                                                              */
@@ -115,16 +96,7 @@ static const char filenames[5][12] = {
 
 static char filepaths[NUM_OF_FILES][FULLPATH_LEN];
 
-/*
- * Block buffer definitions.
- */
+extern adcsample_t io_analog_buffer[IO_ANALOG_BUFFER_DEPTH * IO_ANALOG_NUM_CHANNELS];
 
-typedef uint8_t block_t[512];
-
-#define BLOCK_BUFFER_DEF(SIZE)  BUFFER_STRUCT_DEF(block_t, uint8_t, SIZE)
-#define BLOCK_BUFFER_SIZE       16
-
-typedef BLOCK_BUFFER_DEF(BLOCK_BUFFER_SIZE) block_buffer_t;
-extern block_buffer_t block_buffer;
 
 #endif

--- a/usr/inc/logger.h
+++ b/usr/inc/logger.h
@@ -9,6 +9,9 @@
 #include "logger_timing.h"
 #include "logger_analog_ch.h"
 
+#define BUFFER_OVERWRITE_OLDEST_WHEN_FULL
+#include "buffer.h"
+
 /*
  * Events to wake logger thread when a block is ready to be saved.
  */
@@ -79,6 +82,7 @@ FRESULT sd_mount(FATFS *fs, MMCDriver *mmcd);
 bool sd_init(MMCDriver *mmcd, MMCConfig *mmcconfig);
 FRESULT init_files(void);
 FRESULT init_folders(char *path, size_t n);
+
 /*===========================================================================*/
 /* Logger definitions.                                                              */
 /*===========================================================================*/
@@ -110,5 +114,17 @@ static const char filenames[5][12] = {
 #define FULLPATH_LEN    30      // Max. mumber of characters for full path
 
 static char filepaths[NUM_OF_FILES][FULLPATH_LEN];
+
+/*
+ * Block buffer definitions.
+ */
+
+typedef uint8_t block_t[512];
+
+#define BLOCK_BUFFER_DEF(SIZE)  BUFFER_STRUCT_DEF(block_t, uint8_t, SIZE)
+#define BLOCK_BUFFER_SIZE       16
+
+typedef BLOCK_BUFFER_DEF(BLOCK_BUFFER_SIZE) block_buffer_t;
+extern block_buffer_t block_buffer;
 
 #endif

--- a/usr/inc/logger_analog_ch.h
+++ b/usr/inc/logger_analog_ch.h
@@ -3,17 +3,34 @@
 
 #include "ch.h"
 #include "hal.h"
-#include "logger.h"
+#include "loggerconf.h"
 
 void logger_analog_ch_start(void);
 static void io_adc_error_callback(ADCDriver *adcp, adcerror_t err);
 void io_adc_conv_callback(ADCDriver *adcp);
 
+extern adcsample_t io_analog_buffer[IO_ANALOG_BUFFER_DEPTH * IO_ANALOG_NUM_CHANNELS];
 /*
  * ADC conversion group.
  * Mode:        Circular buffer, 8 samples of 2 channels, SW triggered.
  * Channels:    IN0, IN1, IN2, IN3, IN4, IN5, IN6, IN7.
  */
-extern const ADCConversionGroup adcgrpcfg1;
+static const ADCConversionGroup adcgrpcfg1 = {
+    TRUE,
+    IO_ANALOG_NUM_CHANNELS,
+    io_adc_conv_callback,
+    io_adc_error_callback,
+    0, ADC_CR2_EXTTRIG | (0b100 << ADC_CR2_EXTSEL_Pos),                         /* CR1, CR2 */
+    0,
+    0,                            /* SMPR2 */
+    ADC_SQR1_NUM_CH(IO_ANALOG_NUM_CHANNELS),
+    ADC_SQR2_SQ7_N(ADC_CHANNEL_IN6) | ADC_SQR2_SQ8_N(ADC_CHANNEL_IN7),           /* SQR2 */
+    ADC_SQR3_SQ1_N(ADC_CHANNEL_IN0) | ADC_SQR3_SQ2_N(ADC_CHANNEL_IN1)   | \
+    ADC_SQR3_SQ3_N(ADC_CHANNEL_IN2) | ADC_SQR3_SQ4_N(ADC_CHANNEL_IN3)    | \
+    ADC_SQR3_SQ5_N(ADC_CHANNEL_IN4) | ADC_SQR3_SQ6_N(ADC_CHANNEL_IN5)      \
+};
+
+extern thread_t *logging_thread;
+extern block_buffer_t block_buffer;
 
 #endif

--- a/usr/inc/logger_analog_ch.h
+++ b/usr/inc/logger_analog_ch.h
@@ -9,6 +9,12 @@ void logger_analog_ch_start(void);
 static void io_adc_error_callback(ADCDriver *adcp, adcerror_t err);
 void io_adc_conv_callback(ADCDriver *adcp);
 
+/*
+ * 1 block (512 by) = 32 samples (16 by).
+ * We want to add timestamp in each block, so the maximum of samples is 31.
+ */
+#define IO_ANALOG_BUFFER_DEPTH      62
+
 extern adcsample_t io_analog_buffer[IO_ANALOG_BUFFER_DEPTH * IO_ANALOG_NUM_CHANNELS];
 /*
  * ADC conversion group.

--- a/usr/inc/logger_timing.h
+++ b/usr/inc/logger_timing.h
@@ -2,7 +2,7 @@
 #define _LOGGER_TIMING_H
 
 #include "hal.h"
-#include "logger.h"
+#include "loggerconf.h"
 
 void logger_timing_start(void);
 void io_timer_cb(void);

--- a/usr/loggerconf.h
+++ b/usr/loggerconf.h
@@ -1,0 +1,39 @@
+#ifndef _LOGGER_CONF_H
+#define _LOGGER_CONF_H
+
+#include "buffer.h"
+
+
+/*
+ * Block buffer definitions.
+ */
+
+typedef uint8_t block_t[512];
+
+#define BLOCK_BUFFER_SIZE       (uint8_t)16
+#define BLOCK_BUFFER_DEF(SIZE)  BUFFER_STRUCT_DEF(block_t, uint8_t, (SIZE))
+
+typedef BLOCK_BUFFER_DEF(BLOCK_BUFFER_SIZE) block_buffer_t;
+
+extern block_buffer_t block_buffer;
+
+/*===========================================================================*/
+/* Channels Configuration                                                    */
+/*===========================================================================*/
+
+#define IO_DIGITAL_NUM_CHANNELS     8
+
+#define IO_ANALOG_NUM_CHANNELS      8
+#define IO_ANALOG_BUFFER_DEPTH      60      // 60, 32 samples = 512 by. This gives us a half-buffer of 30 samples, leaving 4 bytes for timestamp (SD block has 512 bytes)
+
+#define LOGGER_FREQUENCY            200
+#define LOGGER_TIMER_PRE            TIMER_FREQUENCY/LOGGER_FREQUENCY
+
+/*===========================================================================*/
+/* Events to wake logger thread when a block is ready to be saved.           */
+/*===========================================================================*/
+
+#define EVT_ADC_HALF_BUFFER EVENT_MASK(0)   // ADC Half Buffer complete event
+#define EVT_ADC_FULL_BUFFER EVENT_MASK(1)   // ADC Full Buffer complete event
+
+#endif /* _LOGGER_CONF_H */

--- a/usr/loggerconf.h
+++ b/usr/loggerconf.h
@@ -1,17 +1,24 @@
 #ifndef _LOGGER_CONF_H
 #define _LOGGER_CONF_H
 
-#include "buffer.h"
+#define BUFFER_POP_EMPTY_ACTION(buf, c) ({})
 
+/* Include buffer library and set buffer to circular mode. */
+#define BUFFER_OVERWRITE_OLDEST_WHEN_FULL
+#include "buffer.h"
 
 /*
  * Block buffer definitions.
  */
 
-typedef uint8_t block_t[512];
+typedef struct {
+    void* blocks;    // Pointer to block(s)
+    uint8_t blocks_tw;    // Blocks to write
+    uint8_t src;    // File index
+} block_element_t;
 
-#define BLOCK_BUFFER_SIZE       (uint8_t)16
-#define BLOCK_BUFFER_DEF(SIZE)  BUFFER_STRUCT_DEF(block_t, uint8_t, (SIZE))
+#define BLOCK_BUFFER_SIZE       16
+#define BLOCK_BUFFER_DEF(SIZE)  BUFFER_STRUCT_DEF(block_element_t, uint8_t, (SIZE))
 
 typedef BLOCK_BUFFER_DEF(BLOCK_BUFFER_SIZE) block_buffer_t;
 
@@ -24,8 +31,6 @@ extern block_buffer_t block_buffer;
 #define IO_DIGITAL_NUM_CHANNELS     8
 
 #define IO_ANALOG_NUM_CHANNELS      8
-#define IO_ANALOG_BUFFER_DEPTH      60      // 60, 32 samples = 512 by. This gives us a half-buffer of 30 samples, leaving 4 bytes for timestamp (SD block has 512 bytes)
-
 #define LOGGER_FREQUENCY            200
 #define LOGGER_TIMER_PRE            TIMER_FREQUENCY/LOGGER_FREQUENCY
 
@@ -33,7 +38,19 @@ extern block_buffer_t block_buffer;
 /* Events to wake logger thread when a block is ready to be saved.           */
 /*===========================================================================*/
 
-#define EVT_ADC_HALF_BUFFER EVENT_MASK(0)   // ADC Half Buffer complete event
-#define EVT_ADC_FULL_BUFFER EVENT_MASK(1)   // ADC Full Buffer complete event
+extern binary_semaphore_t block_to_write_sem;
+
+#define NUM_OF_FILES    5
+
+/*===========================================================================*/
+/* File index of channels definitions.                                       */
+/*===========================================================================*/
+
+#define FIL_ANALOG      0
+#define FIL_DIGITAL     1
+#define FIL_IMU         2
+#define FIL_GPS         3
+#define FIL_CAN         4
+
 
 #endif /* _LOGGER_CONF_H */

--- a/usr/src/logger.c
+++ b/usr/src/logger.c
@@ -4,6 +4,7 @@
  * SD Logging Thread
  */
 thread_t *logging_thread;
+block_buffer_t block_buffer;
 
 THD_WORKING_AREA(waLogThread, 2048);
 THD_FUNCTION(LogThread, arg) {
@@ -50,7 +51,11 @@ void logger_start(void) {
     palSetPadMode(IOPORT3, 13, PAL_MODE_OUTPUT_PUSHPULL);
     palSetPad(IOPORT3, 13);
     palClearPad(IOPORT3, 13);
+    /* Reset buffer common to producers and consumers */
+    buffer_reset(block_buffer);
+    /* Start timers */
     logger_timing_start();
+    /* Start analog channels */
     logger_analog_ch_start();
 }
 

--- a/usr/src/logger_analog_ch.c
+++ b/usr/src/logger_analog_ch.c
@@ -4,7 +4,7 @@ adcsample_t io_analog_buffer[IO_ANALOG_BUFFER_DEPTH * IO_ANALOG_NUM_CHANNELS];
 
 void logger_analog_ch_start(void) {
     adcStart(&ADCD1, NULL);
-    adcStartConversion(&ADCD1, &adcgrpcfg1, io_analog_buffer, IO_ANALOG_BUFFER_DEPTH);
+    adcStartConversion(&ADCD1, &adcgrpcfg1, &io_analog_buffer[1 * IO_ANALOG_NUM_CHANNELS], IO_ANALOG_BUFFER_DEPTH);
 }
 
 static void io_adc_error_callback(ADCDriver *adcp, adcerror_t err) {
@@ -13,18 +13,25 @@ static void io_adc_error_callback(ADCDriver *adcp, adcerror_t err) {
 }
 
 void io_adc_conv_callback(ADCDriver *adcp) {
-    eventmask_t events = 0;
+    int8_t ret = 0;
+    block_element_t tmp_block = {
+        .blocks     = NULL,
+        .blocks_tw  = 1,
+        .src        = FIL_ANALOG
+    };
 
     if (adcIsBufferComplete(adcp)) {
         /* Handle DMA full buffer complete */
-        events |= EVT_ADC_FULL_BUFFER;
+        //TODO: add timestamp in io_analog_buffer[31]
+        tmp_block.blocks = (void *) &io_analog_buffer[31 * IO_ANALOG_NUM_CHANNELS];
     } else {
         /* Handle DMA half buffer complete */
-        events |= EVT_ADC_HALF_BUFFER;
+        //TODO: add timestamp in io_analog_buffer[0]
+        tmp_block.blocks = (void *)io_analog_buffer;
     }
 
     chSysLockFromISR();
-    chEvtSignalI(logging_thread, events);
+    buffer_push(block_buffer, tmp_block, ret);
+    if (ret == 0) chSemSignal(&block_to_write_sem);
     chSysUnlockFromISR();
-    palTogglePad(IOPORT3, 13);
 }

--- a/usr/src/logger_analog_ch.c
+++ b/usr/src/logger_analog_ch.c
@@ -2,26 +2,6 @@
 
 adcsample_t io_analog_buffer[IO_ANALOG_BUFFER_DEPTH * IO_ANALOG_NUM_CHANNELS];
 
-/*
- * ADC conversion group.
- * Mode:        Circular buffer, 8 samples of 2 channels, SW triggered.
- * Channels:    IN0, IN1, IN2, IN3, IN4, IN5, IN6, IN7.
- */
-const ADCConversionGroup adcgrpcfg1 = {
-    TRUE,
-    IO_ANALOG_NUM_CHANNELS,
-    io_adc_conv_callback,
-    io_adc_error_callback,
-    0, ADC_CR2_EXTTRIG | (0b100 << ADC_CR2_EXTSEL_Pos),                         /* CR1, CR2 */
-    0,
-    0,                            /* SMPR2 */
-    ADC_SQR1_NUM_CH(IO_ANALOG_NUM_CHANNELS),
-    ADC_SQR2_SQ7_N(ADC_CHANNEL_IN6) | ADC_SQR2_SQ8_N(ADC_CHANNEL_IN7),           /* SQR2 */
-    ADC_SQR3_SQ1_N(ADC_CHANNEL_IN0) | ADC_SQR3_SQ2_N(ADC_CHANNEL_IN1)   | \
-    ADC_SQR3_SQ3_N(ADC_CHANNEL_IN2) | ADC_SQR3_SQ4_N(ADC_CHANNEL_IN3)    | \
-    ADC_SQR3_SQ5_N(ADC_CHANNEL_IN4) | ADC_SQR3_SQ6_N(ADC_CHANNEL_IN5)      \
-};
-
 void logger_analog_ch_start(void) {
     adcStart(&ADCD1, NULL);
     adcStartConversion(&ADCD1, &adcgrpcfg1, io_analog_buffer, IO_ANALOG_BUFFER_DEPTH);


### PR DESCRIPTION
This PR creates a shared buffer to allow producers to send data to be
saved in SD as blocks.

The structure implemented allows the producer to notify the consumer
when data is available through semaphores, besides sharing the file
and the data (pointer and size in blocks) to be written.

Now the other acquisition channels can be implemented following the
same procedure of data sharing examplified in logger_analog_ch.c's
function io_adc_conv_callback.